### PR TITLE
Add listassetpool, consoleList, fix various problems

### DIFF
--- a/src/client/component/command.cpp
+++ b/src/client/component/command.cpp
@@ -256,57 +256,10 @@ namespace command
 
 			add("consoleList", [](const params& params)
 			{
-				std::string input = params.get(1);
-
-				// "borrowed" these two functions from game_console
-				auto match_compare = [](const std::string& input, const std::string& text, bool exact)
-				{
-					if (exact && text == input) return true;
-					if (!exact && text.find(input) != std::string::npos) return true;
-					return false;
-				};
-
-				auto find_matches = [match_compare](std::string& input, std::vector<std::string>& suggestions,
-				                                              const bool exact)
-				{
-					input = utils::string::to_lower(input);
-
-					for (auto i = 0; i < *game::dvarCount; i++)
-					{
-						if (game::sortedDvars[i] && game::sortedDvars[i]->name)
-						{
-							auto name = utils::string::to_lower(game::sortedDvars[i]->name);
-
-							if (match_compare(input, name, exact))
-							{
-								suggestions.push_back(game::sortedDvars[i]->name);
-							}
-						}
-					}
-
-					auto* cmd = (*game::cmd_functions);
-					while (cmd)
-					{
-						if (cmd->name)
-						{
-							auto name = utils::string::to_lower(cmd->name);
-
-							if (match_compare(input, name, exact))
-							{
-								suggestions.push_back(cmd->name);
-							}
-
-							if (exact && suggestions.size() > 1)
-							{
-								return;
-							}
-						}
-						cmd = cmd->next;
-					}
-				};
+				const std::string input = params.get(1);
 
 				std::vector<std::string> matches;
-				find_matches(input, matches, false);
+				game_console::find_matches(input, matches, false);
 
 				for(auto& match : matches)
 				{

--- a/src/client/component/command.cpp
+++ b/src/client/component/command.cpp
@@ -291,6 +291,72 @@ namespace command
 				game_console::print(game_console::con_type_info,
 				                    "================================ END COMMAND DUMP =================================\n");
 			});
+
+			add("listassetpool", [](const params& params)
+				{
+					if (params.size() < 2)
+					{
+						game_console::print(game_console::con_type_info,
+										"listassetpool <poolnumber>: list all the assets in the specified pool\n");
+
+						for (int i = 0; i < game::ASSET_TYPE_COUNT; i++)
+						{
+							game_console::print(game_console::con_type_info, "%d %s\n", i, game::g_assetNames[i]);
+						}
+					}
+					else
+					{
+						const auto type_index = atoi(params.get(1));
+
+						if (type_index < 0 || type_index >= game::XAssetType::ASSET_TYPE_COUNT)
+						{
+							game_console::print(game_console::con_type_error,
+											"Invalid pool passed must be between [%d, %d]", 0, 
+												game::XAssetType::ASSET_TYPE_COUNT - 1);
+							return;
+						}
+
+						const auto type = static_cast<game::XAssetType>(type_index);
+						game_console::print(game_console::con_type_info, "Listing assets in pool %s",
+											game::g_assetNames[type]);
+
+						auto db_size = 121000;
+						unsigned int* table = game::db_hashTable;
+						game::XAssetEntry* entry;
+						auto num_type_assets = 0, num_type_override_assets = 0;
+
+						do
+						{
+							for (auto hash = *table; hash; hash = entry->nextHash)
+							{
+								entry = &game::g_assetEntryPool[hash];
+								if (entry->asset.type == type)
+								{
+									num_type_assets++;
+									game_console::print(game_console::con_type_info, "%s",
+														game::DB_GetXAssetName(&entry->asset));
+									auto hash_override = entry->nextOverride;
+									if (hash_override)
+									{
+										do
+										{
+											num_type_assets++;
+											num_type_override_assets++;
+											game::XAssetEntry* entry_override = &game::g_assetEntryPool[hash_override];
+											hash_override = game::g_assetEntryPool[hash_override].nextOverride;
+											game_console::print(game_console::con_type_info, "%s | override",
+																game::DB_GetXAssetName(&entry_override->asset));
+										} while (hash_override);
+									}
+								}
+							}
+							table++;
+						} while (db_size--);
+						game_console::print(game_console::con_type_info,
+										"Total of type: %d | Overrides: %d", 
+											num_type_assets, num_type_override_assets);
+					}
+				});
 		}
 
 		static void add_commands_sp()

--- a/src/client/component/command.cpp
+++ b/src/client/component/command.cpp
@@ -257,7 +257,7 @@ namespace command
 			add("consoleList", [](const params& params)
 			{
 				std::string input = params.get(1);
-				std::vector<std::string> matches;
+
 				// "borrowed" these two functions from game_console
 				auto match_compare = [](const std::string& input, const std::string& text, bool exact)
 				{
@@ -266,7 +266,7 @@ namespace command
 					return false;
 				};
 
-				auto find_matches = [&matches, match_compare](std::string& input, std::vector<std::string>& suggestions,
+				auto find_matches = [match_compare](std::string& input, std::vector<std::string>& suggestions,
 				                                              const bool exact)
 				{
 					input = utils::string::to_lower(input);
@@ -279,12 +279,12 @@ namespace command
 
 							if (match_compare(input, name, exact))
 							{
-								matches.push_back(game::sortedDvars[i]->name);
+								suggestions.push_back(game::sortedDvars[i]->name);
 							}
 						}
 					}
 
-					game::cmd_function_s* cmd = (*game::cmd_functions);
+					auto* cmd = (*game::cmd_functions);
 					while (cmd)
 					{
 						if (cmd->name)
@@ -305,6 +305,7 @@ namespace command
 					}
 				};
 
+				std::vector<std::string> matches;
 				find_matches(input, matches, false);
 
 				for(auto& match : matches)

--- a/src/client/component/command.cpp
+++ b/src/client/component/command.cpp
@@ -293,70 +293,70 @@ namespace command
 			});
 
 			add("listassetpool", [](const params& params)
+			{
+				if (params.size() < 2)
 				{
-					if (params.size() < 2)
-					{
-						game_console::print(game_console::con_type_info,
-										"listassetpool <poolnumber>: list all the assets in the specified pool\n");
+					game_console::print(game_console::con_type_info,
+									"listassetpool <poolnumber>: list all the assets in the specified pool\n");
 
-						for (int i = 0; i < game::ASSET_TYPE_COUNT; i++)
-						{
-							game_console::print(game_console::con_type_info, "%d %s\n", i, game::g_assetNames[i]);
-						}
+					for (int i = 0; i < game::ASSET_TYPE_COUNT; i++)
+					{
+						game_console::print(game_console::con_type_info, "%d %s\n", i, game::g_assetNames[i]);
 					}
-					else
+				}
+				else
+				{
+					const auto type_index = atoi(params.get(1));
+
+					if (type_index < 0 || type_index >= game::XAssetType::ASSET_TYPE_COUNT)
 					{
-						const auto type_index = atoi(params.get(1));
+						game_console::print(game_console::con_type_error,
+										"Invalid pool passed must be between [%d, %d]", 0, 
+											game::XAssetType::ASSET_TYPE_COUNT - 1);
+						return;
+					}
 
-						if (type_index < 0 || type_index >= game::XAssetType::ASSET_TYPE_COUNT)
+					const auto type = static_cast<game::XAssetType>(type_index);
+					game_console::print(game_console::con_type_info, "Listing assets in pool %s",
+										game::g_assetNames[type]);
+
+					auto db_size = 121000;
+					unsigned int* table = game::db_hashTable;
+					game::XAssetEntry* entry;
+					auto num_type_assets = 0, num_type_override_assets = 0;
+
+					do
+					{
+						for (auto hash = *table; hash; hash = entry->nextHash)
 						{
-							game_console::print(game_console::con_type_error,
-											"Invalid pool passed must be between [%d, %d]", 0, 
-												game::XAssetType::ASSET_TYPE_COUNT - 1);
-							return;
-						}
-
-						const auto type = static_cast<game::XAssetType>(type_index);
-						game_console::print(game_console::con_type_info, "Listing assets in pool %s",
-											game::g_assetNames[type]);
-
-						auto db_size = 121000;
-						unsigned int* table = game::db_hashTable;
-						game::XAssetEntry* entry;
-						auto num_type_assets = 0, num_type_override_assets = 0;
-
-						do
-						{
-							for (auto hash = *table; hash; hash = entry->nextHash)
+							entry = &game::g_assetEntryPool[hash];
+							if (entry->asset.type == type)
 							{
-								entry = &game::g_assetEntryPool[hash];
-								if (entry->asset.type == type)
+								num_type_assets++;
+								game_console::print(game_console::con_type_info, "%s",
+													game::DB_GetXAssetName(&entry->asset));
+								auto hash_override = entry->nextOverride;
+								if (hash_override)
 								{
-									num_type_assets++;
-									game_console::print(game_console::con_type_info, "%s",
-														game::DB_GetXAssetName(&entry->asset));
-									auto hash_override = entry->nextOverride;
-									if (hash_override)
+									do
 									{
-										do
-										{
-											num_type_assets++;
-											num_type_override_assets++;
-											game::XAssetEntry* entry_override = &game::g_assetEntryPool[hash_override];
-											hash_override = game::g_assetEntryPool[hash_override].nextOverride;
-											game_console::print(game_console::con_type_info, "%s | override",
-																game::DB_GetXAssetName(&entry_override->asset));
-										} while (hash_override);
-									}
+										num_type_assets++;
+										num_type_override_assets++;
+										game::XAssetEntry* entry_override = &game::g_assetEntryPool[hash_override];
+										hash_override = game::g_assetEntryPool[hash_override].nextOverride;
+										game_console::print(game_console::con_type_info, "%s | override",
+															game::DB_GetXAssetName(&entry_override->asset));
+									} while (hash_override);
 								}
 							}
-							table++;
-						} while (db_size--);
-						game_console::print(game_console::con_type_info,
-										"Total of type: %d | Overrides: %d", 
-											num_type_assets, num_type_override_assets);
-					}
-				});
+						}
+						table++;
+					} while (db_size--);
+					game_console::print(game_console::con_type_info,
+									"Total of type: %d | Overrides: %d", 
+										num_type_assets, num_type_override_assets);
+				}
+			});
 		}
 
 		static void add_commands_sp()

--- a/src/client/component/fastfiles.cpp
+++ b/src/client/component/fastfiles.cpp
@@ -63,39 +63,6 @@ namespace fastfiles
 				game::DB_LoadXAssets(&info, 1u, game::DBSyncMode::DB_LOAD_SYNC);
 			});
 
-			command::add("materiallist", [](const command::params& params)
-			{
-				game::DB_EnumXAssets_FastFile(game::ASSET_TYPE_MATERIAL, [](const game::XAssetHeader header, void*)
-				{
-					if (header.material && header.material->name)
-					{
-						printf("%s\n", header.material->name);
-					}
-				}, 0, false);
-			});
-
-			command::add("fontlist", [](const command::params& params)
-			{
-				game::DB_EnumXAssets_FastFile(game::ASSET_TYPE_FONT, [](const game::XAssetHeader header, void*)
-				{
-					if (header.font && header.font->fontName)
-					{
-						printf("%s\n", header.font->fontName);
-					}
-				}, 0, false);
-			});
-
-			command::add("rawfilelist", [](const command::params& params)
-			{
-				game::DB_EnumXAssets_FastFile(game::ASSET_TYPE_RAWFILE, [](const game::XAssetHeader header, void*)
-				{
-					if (header.rawfile && header.rawfile->name)
-					{
-						printf("%s\n", header.rawfile->name);
-					}
-				}, 0, false);
-			});
-
 			command::add("g_poolSizes", []()
 			{
 				for (auto i = 0; i < game::ASSET_TYPE_COUNT; i++)

--- a/src/client/component/game_console.cpp
+++ b/src/client/component/game_console.cpp
@@ -496,6 +496,7 @@ namespace game_console
 			{
 				clear();
 				con.line_count = 0;
+				con.display_line_offset = 0;
 				con.output.clear();
 				history_index = -1;
 				history.clear();
@@ -716,6 +717,7 @@ namespace game_console
 			{
 				clear();
 				con.line_count = 0;
+				con.display_line_offset = 0;
 				con.output.clear();
 				history_index = -1;
 				history.clear();

--- a/src/client/component/game_console.cpp
+++ b/src/client/component/game_console.cpp
@@ -171,57 +171,7 @@ namespace game_console
 			const auto _y = con.globals.font_height + con.globals.y + (con.globals.font_height * (line + 1)) + 15.0f;
 
 			game::R_AddCmdDrawText(text, 0x7FFFFFFF, console_font, con.globals.x + offset, _y, 1.0f, 1.0f, 0.0f, color,
-			                       0);
-		}
-
-		bool match_compare(const std::string& input, const std::string& text, const bool exact)
-		{
-			if (exact && text == input) return true;
-			if (!exact && text.find(input) != std::string::npos) return true;
-			return false;
-		}
-
-		void find_matches(std::string input, std::vector<std::string>& suggestions, const bool exact)
-		{
-			input = utils::string::to_lower(input);
-
-			for (int i = 0; i < *game::dvarCount; i++)
-			{
-				if (game::sortedDvars[i] && game::sortedDvars[i]->name)
-				{
-					std::string name = utils::string::to_lower(game::sortedDvars[i]->name);
-
-					if (match_compare(input, name, exact))
-					{
-						suggestions.push_back(game::sortedDvars[i]->name);
-					}
-
-					if (exact && suggestions.size() > 1)
-					{
-						return;
-					}
-				}
-			}
-
-			game::cmd_function_s* cmd = (*game::cmd_functions);
-			while (cmd)
-			{
-				if (cmd->name)
-				{
-					std::string name = utils::string::to_lower(cmd->name);
-
-					if (match_compare(input, name, exact))
-					{
-						suggestions.push_back(cmd->name);
-					}
-
-					if (exact && suggestions.size() > 1)
-					{
-						return;
-					}
-				}
-				cmd = cmd->next;
-			}
+				0);
 		}
 
 		void draw_input()
@@ -674,6 +624,56 @@ namespace game_console
 		}
 
 		return true;
+	}
+
+	bool match_compare(const std::string& input, const std::string& text, const bool exact)
+	{
+		if (exact && text == input) return true;
+		if (!exact && text.find(input) != std::string::npos) return true;
+		return false;
+	}
+
+	void find_matches(std::string input, std::vector<std::string>& suggestions, const bool exact)
+	{
+		input = utils::string::to_lower(input);
+
+		for (int i = 0; i < *game::dvarCount; i++)
+		{
+			if (game::sortedDvars[i] && game::sortedDvars[i]->name)
+			{
+				std::string name = utils::string::to_lower(game::sortedDvars[i]->name);
+
+				if (game_console::match_compare(input, name, exact))
+				{
+					suggestions.push_back(game::sortedDvars[i]->name);
+				}
+
+				if (exact && suggestions.size() > 1)
+				{
+					return;
+				}
+			}
+		}
+
+		game::cmd_function_s* cmd = (*game::cmd_functions);
+		while (cmd)
+		{
+			if (cmd->name)
+			{
+				std::string name = utils::string::to_lower(cmd->name);
+
+				if (game_console::match_compare(input, name, exact))
+				{
+					suggestions.push_back(cmd->name);
+				}
+
+				if (exact && suggestions.size() > 1)
+				{
+					return;
+				}
+			}
+			cmd = cmd->next;
+		}
 	}
 
 	class component final : public component_interface

--- a/src/client/component/game_console.cpp
+++ b/src/client/component/game_console.cpp
@@ -494,7 +494,9 @@ namespace game_console
 		if (key == game::keyNum_t::K_F10)
 		{
 			if (game::mp::svs_clients[localClientNum].header.state >= 1)
+			{
 				return false;
+			}
 			
 			game::Cmd_ExecuteSingleCommand(localClientNum, 0, "lui_open menu_systemlink_join\n");
 		}

--- a/src/client/component/game_console.cpp
+++ b/src/client/component/game_console.cpp
@@ -542,6 +542,9 @@ namespace game_console
 	{
 		if (key == game::keyNum_t::K_F10)
 		{
+			if (game::mp::svs_clients[localClientNum].header.state >= 1)
+				return false;
+			
 			game::Cmd_ExecuteSingleCommand(localClientNum, 0, "lui_open menu_systemlink_join\n");
 		}
 

--- a/src/client/component/game_console.cpp
+++ b/src/client/component/game_console.cpp
@@ -379,7 +379,7 @@ namespace game_console
 			const auto height = ((con.screen_max[1] - con.screen_min[1]) - 32.0f) - 12.0f;
 
 			game::R_AddCmdDrawText(game::Dvar_FindVar("version")->current.string, 0x7FFFFFFF, console_font, x,
-			                       ((height - 16.0f) + y) + console_font->pixelHeight, 1.0f, 1.0f, 0.0f, color_s1, 0);
+			                       ((height - 12.0f) + y) + console_font->pixelHeight, 1.0f, 1.0f, 0.0f, color_s1, 0);
 
 			draw_output_scrollbar(x, y, width, height);
 			draw_output_text(x, y);

--- a/src/client/component/game_console.hpp
+++ b/src/client/component/game_console.hpp
@@ -14,4 +14,7 @@ namespace game_console
 
 	bool console_char_event(int local_client_num, int key);
 	bool console_key_event(int local_client_num, int key, int down);
+
+	bool match_compare(const std::string& input, const std::string& text, const bool exact);
+	void find_matches(std::string input, std::vector<std::string>& suggestions, const bool exact);
 }

--- a/src/client/component/party.cpp
+++ b/src/client/component/party.cpp
@@ -210,6 +210,12 @@ namespace party
 
 			if (!game::environment::is_dedi())
 			{
+				if(game::SV_Loaded())
+				{
+					const auto* args = "Leave";
+					game::UI_RunMenuScript(0, &args);
+				}
+				
 				perform_game_initialization();
 			}
 
@@ -238,11 +244,8 @@ namespace party
 				command::execute(utils::string::va("party_maxplayers %i", maxclients->current.integer), true);
 			}*/
 
-			// StartServer
-			reinterpret_cast<void(*)(unsigned int)>(0x140492260)(0);
-
-			//game::SV_StartMapForParty(0, mapname.data(), false, false);
-			//return;
+			const auto* args = "StartServer";
+			game::UI_RunMenuScript(0, &args);
 		}
 	}
 

--- a/src/client/game/structs.hpp
+++ b/src/client/game/structs.hpp
@@ -1040,6 +1040,22 @@ namespace game
 		StringTable* stringTable;
 	};
 
+	struct XAsset
+	{
+		XAssetType type;
+		XAssetHeader header;
+	};
+
+	struct XAssetEntry
+	{
+		XAsset asset;
+		char zoneIndex;
+		volatile char inuseMask;
+		unsigned int nextHash;
+		unsigned int nextOverride;
+		unsigned int nextPoolEntry;
+	};
+
 	enum TestClientType
 	{
 		TC_NONE = 0x0,

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -193,6 +193,8 @@ namespace game
 	WEAK symbol<SOCKET> query_socket{0, 0x14B5B9180};
 
 	WEAK symbol<void*> DB_XAssetPool{0x140804690, 0x1409B40D0};
+	WEAK symbol<unsigned int> db_hashTable{ 0x142C3E050, 0x143716B10 };
+	WEAK symbol<XAssetEntry> g_assetEntryPool{ 0x142CC2400, 0x14379F100 };
 	WEAK symbol<int> g_poolSize{0x140804140, 0x1409B4B90};
 	WEAK symbol<const char*> g_assetNames{0x140803C90, 0x1409B3180};
 

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -41,7 +41,7 @@ namespace game
 
 	WEAK symbol<void(XAssetType type, void (__cdecl* func)(XAssetHeader, void*), void* inData, bool includeOverride)>
 	DB_EnumXAssets_FastFile{0x14017D7C0, 0x14026EC10};
-	WEAK symbol<const char* (const XAsset* asset)> DB_GetXAssetName{ 0x140151C00, 0x140240DD0 };
+	WEAK symbol<const char* (const XAsset* asset)> DB_GetXAssetName{0x140151C00, 0x140240DD0};
 	WEAK symbol<int(XAssetType type)> DB_GetXAssetTypeSize{0x140151C20, 0x140240DF0};
 	WEAK symbol<void(XZoneInfo* zoneInfo, unsigned int zoneCount, DBSyncMode syncMode)> DB_LoadXAssets{
 		0x1402F8B50, 0x140270F30
@@ -194,8 +194,8 @@ namespace game
 	WEAK symbol<SOCKET> query_socket{0, 0x14B5B9180};
 
 	WEAK symbol<void*> DB_XAssetPool{0x140804690, 0x1409B40D0};
-	WEAK symbol<unsigned int> db_hashTable{ 0x142C3E050, 0x143716B10 };
-	WEAK symbol<XAssetEntry> g_assetEntryPool{ 0x142CC2400, 0x14379F100 };
+	WEAK symbol<unsigned int> db_hashTable{0x142C3E050, 0x143716B10};
+	WEAK symbol<XAssetEntry> g_assetEntryPool{0x142CC2400, 0x14379F100};
 	WEAK symbol<int> g_poolSize{0x140804140, 0x1409B4B90};
 	WEAK symbol<const char*> g_assetNames{0x140803C90, 0x1409B3180};
 

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -41,6 +41,7 @@ namespace game
 
 	WEAK symbol<void(XAssetType type, void (__cdecl* func)(XAssetHeader, void*), void* inData, bool includeOverride)>
 	DB_EnumXAssets_FastFile{0x14017D7C0, 0x14026EC10};
+	WEAK symbol<const char* (const XAsset* asset)> DB_GetXAssetName{ 0x140151C00, 0x140240DD0 };
 	WEAK symbol<int(XAssetType type)> DB_GetXAssetTypeSize{0x140151C20, 0x140240DF0};
 	WEAK symbol<void(XZoneInfo* zoneInfo, unsigned int zoneCount, DBSyncMode syncMode)> DB_LoadXAssets{
 		0x1402F8B50, 0x140270F30

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -41,6 +41,10 @@ namespace game
 
 	WEAK symbol<void(XAssetType type, void (__cdecl* func)(XAssetHeader, void*), void* inData, bool includeOverride)>
 	DB_EnumXAssets_FastFile{0x14017D7C0, 0x14026EC10};
+	WEAK symbol<void(XAssetType type, void(__cdecl* func)(game::XAssetHeader, void*), const void* inData, bool includeOverride)>
+	DB_EnumXAssets_Internal{ 0x14017D830, 0x14026EC80 };
+	WEAK symbol<game::XAssetEntry(game::XAssetType type, const char* name)>
+	DB_FindXAssetEntry{ 0x14017D830, 0x14026F020 };
 	WEAK symbol<const char* (const XAsset* asset)> DB_GetXAssetName{0x140151C00, 0x140240DD0};
 	WEAK symbol<int(XAssetType type)> DB_GetXAssetTypeSize{0x140151C20, 0x140240DF0};
 	WEAK symbol<void(XZoneInfo* zoneInfo, unsigned int zoneCount, DBSyncMode syncMode)> DB_LoadXAssets{


### PR DESCRIPTION
- Fix console display line offset not being reset after calling clear
- Fix opening server menu in a match causing LUI errors to show in console
- Fix LUI crashing whenever calling a map inside a map which was only seen clientside
- Lower the version text display in console to fix text overlapping
- Add listassetpool command replacing the specific pool listing commands
- Add consoleList command to display cmd/dvars