### PR TITLE
unlock safeArea_*

### DIFF
--- a/src/client/component/patches.cpp
+++ b/src/client/component/patches.cpp
@@ -286,6 +286,13 @@ namespace patches
 
 			// some anti tamper thing that kills performance
 			dvars::override::Dvar_RegisterInt("dvl", 0, 0, 0, game::DVAR_FLAG_NONE);
+			
+			// un-cheat and un-readonly safeArea_* & give dvars saved flags (WIP)
+			// look into: safeArea_adjusted_* always being set to 1?
+			dvars::override::Dvar_RegisterFloat("safeArea_adjusted_horizontal", 1, 0, 1, game::DVAR_FLAG_SAVED);
+			dvars::override::Dvar_RegisterFloat("safeArea_adjusted_vertical", 1, 0, 1, game::DVAR_FLAG_SAVED);
+			dvars::override::Dvar_RegisterFloat("safeArea_horizontal", 1, 0, 1, game::DVAR_FLAG_SAVED);
+			dvars::override::Dvar_RegisterFloat("safeArea_vertical", 1, 0, 1, game::DVAR_FLAG_SAVED);
 		}
 
 		static void patch_sp()

--- a/src/client/component/patches.cpp
+++ b/src/client/component/patches.cpp
@@ -287,8 +287,9 @@ namespace patches
 			// some anti tamper thing that kills performance
 			dvars::override::Dvar_RegisterInt("dvl", 0, 0, 0, game::DVAR_FLAG_NONE);
 			
-			// un-cheat and un-readonly safeArea_* & give dvars saved flags (WIP)
-			// look into: safeArea_adjusted_* always being set to 1?
+			// unlock safeArea_*
+			utils::hook::nop(0x140219F62, 5); // not allowing change on horizontal
+			//utils::hook::nop(0x140219F89, 5);
 			dvars::override::Dvar_RegisterFloat("safeArea_adjusted_horizontal", 1, 0, 1, game::DVAR_FLAG_SAVED);
 			dvars::override::Dvar_RegisterFloat("safeArea_adjusted_vertical", 1, 0, 1, game::DVAR_FLAG_SAVED);
 			dvars::override::Dvar_RegisterFloat("safeArea_horizontal", 1, 0, 1, game::DVAR_FLAG_SAVED);


### PR DESCRIPTION
unlock & un-cheat safeArea_* dvars and allow change on horizontal safezone (vertical causes game crashes + it isn't different from console anyways)

this feature addresses #75