### PR TITLE
hooked dvar register vector2, modified cg_hudChatPosition and matched…

### DIFF
--- a/src/client/component/dvars.cpp
+++ b/src/client/component/dvars.cpp
@@ -26,6 +26,14 @@ namespace dvars
 		float max{};
 	};
 
+	struct dvar_vector2 : dvar_base
+	{
+		float x{};
+		float y{};
+		float min{};
+		float max{};
+	};
+
 	struct dvar_int : dvar_base
 	{
 		int value{};
@@ -92,6 +100,7 @@ namespace dvars
 		static std::unordered_map<std::string, dvar_float> register_float_overrides;
 		static std::unordered_map<std::string, dvar_int> register_int_overrides;
 		static std::unordered_map<std::string, dvar_string> register_string_overrides;
+		static std::unordered_map<std::string, dvar_vector2> register_vector2_overrides;
 
 		static std::unordered_map<std::string, bool> set_bool_overrides;
 		static std::unordered_map<std::string, float> set_float_overrides;
@@ -144,6 +153,18 @@ namespace dvars
 			register_string_overrides[name] = std::move(values);
 		}
 
+		void Dvar_RegisterVector2(const std::string& name, float x, float y, float min, float max,
+                                  const unsigned int flags, const std::string& description)
+		{
+			dvar_vector2 values;
+			values.x = x;
+			values.y = y;
+			values.min = min;
+			values.max = max;
+			values.description = description;
+			register_vector2_overrides[name] = std::move(values);
+		}
+
 		void Dvar_SetBool(const std::string& name, const bool value)
 		{
 			set_bool_overrides[name] = value;
@@ -169,6 +190,7 @@ namespace dvars
 	utils::hook::detour dvar_register_float_hook;
 	utils::hook::detour dvar_register_int_hook;
 	utils::hook::detour dvar_register_string_hook;
+	utils::hook::detour dvar_register_vector2_hook;
 
 	utils::hook::detour dvar_set_bool_hook;
 	utils::hook::detour dvar_set_float_hook;
@@ -231,6 +253,23 @@ namespace dvars
 		}
 
 		return dvar_register_string_hook.invoke<game::dvar_t*>(name, value, flags, description);
+	}
+
+	game::dvar_t* dvar_register_vector2(const char* name, float x, float y, float min, float max,
+		                                unsigned int flags, const char* description)
+	{
+		auto* var = find_dvar(override::register_vector2_overrides, name);
+		if (var)
+		{
+			x = var->x;
+			y = var->y;
+			min = var->min;
+			max = var->max;
+			flags = var->flags;
+			description = var->description.data();
+		}
+
+		return dvar_register_vector2_hook.invoke<game::dvar_t*>(name, x, y, min, max, flags, description);
 	}
 
 	void dvar_set_bool(game::dvar_t* dvar, bool boolean)
@@ -310,6 +349,7 @@ namespace dvars
 			dvar_register_float_hook.create(SELECT_VALUE(0x140371C20, 0x1404C0FB0), &dvar_register_float);
 			dvar_register_int_hook.create(SELECT_VALUE(0x140371CF0, 0x1404C1080), &dvar_register_int);
 			dvar_register_string_hook.create(SELECT_VALUE(0x140372050, 0x1404C1450), &dvar_register_string);
+			dvar_register_vector2_hook.create(SELECT_VALUE(0x140372120, 0x1404C1520), &dvar_register_vector2);
 
 			dvar_set_bool_hook.create(SELECT_VALUE(0x140372B70, 0x1404C1F30), &dvar_set_bool);
 			dvar_set_float_hook.create(SELECT_VALUE(0x140373420, 0x1404C2A10), &dvar_set_float);

--- a/src/client/component/dvars.hpp
+++ b/src/client/component/dvars.hpp
@@ -12,10 +12,11 @@ namespace dvars
 
 	namespace override
 	{
-		void Dvar_RegisterBool(const std::string& name, bool value, unsigned int flags, const std::string& description = "");
-		void Dvar_RegisterFloat(const std::string& name, float value, float min, float max, unsigned int flags, const std::string& description = "");
-		void Dvar_RegisterInt(const std::string& name, int value, int min, int max, unsigned int flags, const std::string& description = "");
-		void Dvar_RegisterString(const std::string& name, const std::string& value, unsigned int flags, const std::string& description = "");
+		void Dvar_RegisterBool(const std::string& name, bool value, const unsigned int flags, const std::string& description = "");
+		void Dvar_RegisterFloat(const std::string& name, float value, float min, float max, const unsigned int flags, const std::string& description = "");
+		void Dvar_RegisterInt(const std::string& name, int value, int min, int max, const unsigned int flags, const std::string& description = "");
+		void Dvar_RegisterString(const std::string& name, const std::string& value, const unsigned int flags, const std::string& description = "");
+		void Dvar_RegisterVector2(const std::string& name, float x, float y, float min, float max, const unsigned int flags, const std::string& description = "");
 
 		void Dvar_SetBool(const std::string& name, bool boolean);
 		void Dvar_SetFloat(const std::string& name, float fl);

--- a/src/client/component/patches.cpp
+++ b/src/client/component/patches.cpp
@@ -294,6 +294,9 @@ namespace patches
 			dvars::override::Dvar_RegisterFloat("safeArea_adjusted_vertical", 1, 0, 1, game::DVAR_FLAG_SAVED);
 			dvars::override::Dvar_RegisterFloat("safeArea_horizontal", 1, 0, 1, game::DVAR_FLAG_SAVED);
 			dvars::override::Dvar_RegisterFloat("safeArea_vertical", 1, 0, 1, game::DVAR_FLAG_SAVED);
+
+			// move chat position on the screen above menu splashes
+			dvars::override::Dvar_RegisterVector2("cg_hudChatPosition", 5, 170, 0, 640, game::DVAR_FLAG_SAVED);
 		}
 
 		static void patch_sp()

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -81,6 +81,8 @@ namespace game
 	Dvar_RegisterInt{0x140371CF0, 0x1404C1080};
 	WEAK symbol<dvar_t*(const char* dvarName, const char* value, unsigned int flags, const char* description)>
 	Dvar_RegisterString{0x140372050, 0x1404C1450};
+	WEAK symbol<dvar_t* (const char* name, float x, float y, float min, float max,
+		                 unsigned int flags, const char* description)> Dvar_RegisterVec2{0x140372120, 0x1404C1520};
 	WEAK symbol<dvar_t*(const char* dvarName, float x, float y, float z, float w, float min, float max,
 	                    unsigned int flags, const char* description)> Dvar_RegisterVec4{0x140372430, 0x1404C1800};
 


### PR DESCRIPTION
… function decl in dvar.hpp with dvar.cpp for all register functions.

tested on different servers and also 2 resolutions. chat should remain between menu splashes and compass even when multiple messages are typed.