### PR TITLE
Small QOL changes mostly for dedicated server owners.

### DIFF
--- a/src/client/component/command.cpp
+++ b/src/client/component/command.cpp
@@ -313,7 +313,7 @@ namespace command
 							line.append("\"");
 							line.append(game::Dvar_ValueToString(dvar, dvar->current));
 							line.append("\"\r\n");
-							utils::io::write_file(filename, line, i == 0 ? false : true);
+							utils::io::write_file(filename, line, i != 0);
 						}
 						console::info("%s \"%s\"\n", dvar->name,
 						                    game::Dvar_ValueToString(dvar, dvar->current));
@@ -347,7 +347,7 @@ namespace command
 							//It's 10.2020 and still no std:format in vs :<
 							std::string line = cmd->name;
 							line.append("\r\n");
-							utils::io::write_file(filename, line, i == 0 ? false : true);
+							utils::io::write_file(filename, line, i != 0);
 						}
 						console::info("%s\n", cmd->name);
 						i++;

--- a/src/client/component/command.cpp
+++ b/src/client/component/command.cpp
@@ -9,6 +9,7 @@
 #include <utils/hook.hpp>
 #include <utils/string.hpp>
 #include <utils/memory.hpp>
+#include "utils/io.hpp"
 
 namespace command
 {
@@ -287,14 +288,33 @@ namespace command
 				console::info("Total %i matches\n", matches.size());
 			});
 
-			add("dvarDump", []()
+			add("dvarDump", [](const params& argument)
 			{
 				console::info("================================ DVAR DUMP ========================================\n");
+				std::string filename;
+				if (argument.size() == 2)
+				{
+					filename = "s1x/";
+					filename.append(argument[1]);
+					if (!filename.ends_with(".txt"))
+					{
+						filename.append(".txt");
+					}
+				}
 				for (auto i = 0; i < *game::dvarCount; i++)
 				{
 					const auto dvar = game::sortedDvars[i];
 					if (dvar)
 					{
+						if (argument.size() == 2)
+						{
+							//It's 10.2020 and still no std:format in vs :<
+							std::string line = dvar->name;
+							line.append("\"");
+							line.append(game::Dvar_ValueToString(dvar, dvar->current));
+							line.append("\"\r\n");
+							utils::io::write_file(filename, line, i == 0 ? false : true);
+						}
 						console::info("%s \"%s\"\n", dvar->name,
 						                    game::Dvar_ValueToString(dvar, dvar->current));
 					}
@@ -303,15 +323,32 @@ namespace command
 				console::info("================================ END DVAR DUMP ====================================\n");
 			});
 
-			add("commandDump", []()
+			add("commandDump", [](const params& argument)
 			{
 				console::info("================================ COMMAND DUMP =====================================\n");
 				game::cmd_function_s* cmd = (*game::cmd_functions);
+				std::string filename;
+				if (argument.size() == 2)
+				{ 
+					filename = "s1x/";
+					filename.append(argument[1]);
+					if (!filename.ends_with(".txt"))
+					{
+						filename.append(".txt");
+					}
+				}
 				int i = 0;
 				while (cmd)
 				{
 					if (cmd->name)
 					{
+						if (argument.size() == 2)
+						{
+							//It's 10.2020 and still no std:format in vs :<
+							std::string line = cmd->name;
+							line.append("\r\n");
+							utils::io::write_file(filename, line, i == 0 ? false : true);
+						}
 						console::info("%s\n", cmd->name);
 						i++;
 					}

--- a/src/client/component/command.cpp
+++ b/src/client/component/command.cpp
@@ -306,7 +306,7 @@ namespace command
 					const auto dvar = game::sortedDvars[i];
 					if (dvar)
 					{
-						if (argument.size() == 2)
+						if (!filename.empty())
 						{
 							//It's 10.2020 and still no std:format in vs :<
 							std::string line = dvar->name;
@@ -342,7 +342,7 @@ namespace command
 				{
 					if (cmd->name)
 					{
-						if (argument.size() == 2)
+						if (!filename.empty())
 						{
 							//It's 10.2020 and still no std:format in vs :<
 							std::string line = cmd->name;

--- a/src/client/component/patches.cpp
+++ b/src/client/component/patches.cpp
@@ -301,6 +301,9 @@ namespace patches
 
 			// move chat position on the screen above menu splashes
 			dvars::override::Dvar_RegisterVector2("cg_hudChatPosition", 5, 170, 0, 640, game::DVAR_FLAG_SAVED);
+
+			// allow servers to check for new packages more often
+			dvars::override::Dvar_RegisterInt("sv_network_fps", 1000, 20, 1000, game::DVAR_FLAG_SAVED);
 		}
 
 		static void patch_sp()


### PR DESCRIPTION
* CommandDump and dvarDump now accept a file name as an optional argument to store the output on disk.
    * There might be a bit of performance that could be gained by not opening the file, appending to it and closing it again for every line. But its only run on demand so it should be fine.
* sv_network_fps unlocked.
    * Cheat protection removed.
    * Bumped maximum and default to 1000 times a second.
* Added sv_autoPriority to temporarily lower our process priority while we load a new map to not cause lag spikes on other servers that have their main thread on the same CPU core as we do.
    * This assumes that the dedicated servers are running with a priority above normal as it will lower it to normal during the map rotation.