### PR TITLE
Fix service not available disconnect

### DIFF
--- a/src/client/component/demonware.cpp
+++ b/src/client/component/demonware.cpp
@@ -430,6 +430,7 @@ namespace demonware
 			utils::hook::inject(0x140038A07, "http://prod.umbrella.demonware.net/v1.0/");
 
 			utils::hook::set<uint8_t>(0x140437CC0, 0xC3); // SV_SendMatchData
+			utils::hook::set<uint8_t>(0x140560D70, 0xC3); // Live_CheckForFullDisconnect
 		}
 
 		void pre_destroy() override


### PR DESCRIPTION
When loading the map takes too long the game can give the error:
"The Call of Duty: Advanced Warfare service is not available at this time. Please try again later."

This happens often on lower end computers.
Live_CheckForFullDisconnect seems to be the cause for this, which I have patched for this fix.