### PR TITLE
(Discord) Fix server's player max + Private Match

### DIFF
--- a/src/client/component/discord.cpp
+++ b/src/client/component/discord.cpp
@@ -143,7 +143,7 @@ namespace discord
 
 		static void errored(const int error_code, const char* message)
 		{
-			console::info("Discord: Error (%i): %s\n", error_code, message);
+			console::error("Discord: Error (%i): %s\n", error_code, message);
 		}
 	};
 }

--- a/src/client/component/discord.cpp
+++ b/src/client/component/discord.cpp
@@ -78,6 +78,9 @@ namespace discord
 					discord_presence.startTimestamp = std::chrono::duration_cast<std::chrono::seconds>(
 						std::chrono::system_clock::now().time_since_epoch()).count();
 				}
+
+				discord_presence.largeImageKey = game::Dvar_FindVar("ui_mapname")->current.string;
+				discord_presence.largeImageText = game::UI_GetMapDisplayName(game::Dvar_FindVar("ui_mapname")->current.string);
 			}
 
 			Discord_UpdatePresence(&discord_presence);

--- a/src/client/component/party.cpp
+++ b/src/client/component/party.cpp
@@ -26,6 +26,7 @@ namespace party
 		} connect_state;
 
 		std::string sv_motd;
+		int sv_maxclients;
 
 		void perform_game_initialization()
 		{
@@ -271,6 +272,11 @@ namespace party
 			const auto* args = "StartServer";
 			game::UI_RunMenuScript(0, &args);
 		}
+	}
+
+	int server_client_count()
+	{
+		return party::sv_maxclients;
 	}
 
 	class component final : public component_interface
@@ -595,6 +601,7 @@ namespace party
 				}
 
 				party::sv_motd = info.get("sv_motd");
+				party::sv_maxclients = std::stoi(info.get("sv_maxclients"));
 
 				connect_to_party(target, mapname, gametype);
 			});

--- a/src/client/component/party.hpp
+++ b/src/client/component/party.hpp
@@ -8,6 +8,8 @@ namespace party
 	void connect(const game::netadr_s& target);
 	void start_map(const std::string& mapname);
 
+	int server_client_count();
+
 	int get_client_num_by_name(const std::string& name);
 
 	int get_client_count();


### PR DESCRIPTION
RPC now properly displays the server's actual max player count.
![image](https://user-images.githubusercontent.com/64374267/119463140-16362500-bd07-11eb-8d4b-66988a90d6f9.png)

and also now properly detects when you are in Private Match
![image](https://user-images.githubusercontent.com/64374267/119463232-2d751280-bd07-11eb-8431-5f13f40e3e5e.png)