### PR TITLE
Check for invalid reliable ack

### DIFF
--- a/src/client/component/patches.cpp
+++ b/src/client/component/patches.cpp
@@ -2,6 +2,7 @@
 #include "loader/component_loader.hpp"
 #include "command.hpp"
 #include "console.hpp"
+#include "network.hpp"
 #include "game/game.hpp"
 #include "game/dvars.hpp"
 #include "scheduler.hpp"
@@ -197,6 +198,20 @@ namespace patches
 
 			cmd_lui_notify_server_hook.invoke<void>(ent);
 		}
+
+		void sv_execute_client_message_stub(game::mp::client_t* client, game::msg_t* msg)
+		{
+			if (client->reliableAcknowledge < 0)
+			{
+				client->reliableAcknowledge = client->reliableSequence;
+				console::info("Negative reliableAcknowledge from %s - cl->reliableSequence is %i, reliableAcknowledge is %i\n",
+					client->name, client->reliableSequence, client->reliableAcknowledge);
+				network::send(client->header.remoteAddress, "error", "EXE_LOSTRELIABLECOMMANDS", '\n');
+				return;
+			}
+
+			reinterpret_cast<void(*)(game::mp::client_t*, game::msg_t*)>(0x14043AA90)(client, msg);
+		}
 	}
 
 	class component final : public component_interface
@@ -331,6 +346,9 @@ namespace patches
       
 			// Prevent clients from ending the game as non host by sending 'end_game' lui notification
 			cmd_lui_notify_server_hook.create(0x1402E9390, cmd_lui_notify_server_stub);
+
+			// Prevent clients from sending invalid reliableAcknowledge
+			utils::hook::call(0x140443051, sv_execute_client_message_stub);
 		}
 
 		static void patch_sp()

--- a/src/client/game/structs.hpp
+++ b/src/client/game/structs.hpp
@@ -1385,16 +1385,19 @@ namespace game
 		struct client_t
 		{
 			clientHeader_t header;
-			char __pad0[268916];
+			char __pad0[3044];
+			int reliableSequence;
+			int reliableAcknowledge;
+			char __pad1[265864];
 			gentity_s* gentity; // 268976
 			char name[32]; // 268984
-			char __pad1[8];
+			char __pad2[8];
 			int nextSnapshotTime; // 269024
-			char __pad2[544];
+			char __pad3[544];
 			LiveClientDropType liveDropRequest; //269572
-			char __pad3[24];
+			char __pad4[24];
 			TestClientType testClient; // 269600
-			char __pad4[391700];
+			char __pad5[391700];
 		}; // size = 661304
 	}
 


### PR DESCRIPTION
This is the port of the fix I made for iw6x [https://github.com/XLabsProject/iw6x-client/pull/492](XLabsProject).

Then again, by hooking a function inside CL_WritePacket an attacker can send invalid data to the server and make the server thread hang.

I tested the fix and it works as intended.