### PR TITLE
[Command] Use STD format

### DIFF
--- a/src/client/component/command.cpp
+++ b/src/client/component/command.cpp
@@ -309,7 +309,7 @@ namespace command
 						if (!filename.empty())
 						{
 							const auto line = std::format("{} \"{}\"\r\n", dvar->name,
-											game::Dvar_ValueToString(dvar, dvar->current));
+										game::Dvar_ValueToString(dvar, dvar->current));
 							utils::io::write_file(filename, line, i != 0);
 						}
 						console::info("%s \"%s\"\n", dvar->name,

--- a/src/client/component/command.cpp
+++ b/src/client/component/command.cpp
@@ -308,11 +308,8 @@ namespace command
 					{
 						if (!filename.empty())
 						{
-							//It's 10.2020 and still no std:format in vs :<
-							std::string line = dvar->name;
-							line.append("\"");
-							line.append(game::Dvar_ValueToString(dvar, dvar->current));
-							line.append("\"\r\n");
+							const auto line = std::format("{} \"{}\"\r\n", dvar->name,
+											game::Dvar_ValueToString(dvar, dvar->current));
 							utils::io::write_file(filename, line, i != 0);
 						}
 						console::info("%s \"%s\"\n", dvar->name,
@@ -344,9 +341,7 @@ namespace command
 					{
 						if (!filename.empty())
 						{
-							//It's 10.2020 and still no std:format in vs :<
-							std::string line = cmd->name;
-							line.append("\r\n");
+							const auto line = std::format("{}\r\n", cmd->name);
 							utils::io::write_file(filename, line, i != 0);
 						}
 						console::info("%s\n", cmd->name);


### PR DESCRIPTION
Some comments inside the command module remarked that at the time of writing std::format was unavailable.
Seems like a good addition to me.

Code was tested, you can see from the screenshots what a dump looks like.


![DvarDump](https://user-images.githubusercontent.com/37080671/141524498-3b1696b4-f99b-4b38-a98f-77db89a56fe6.png)
![Cmd](https://user-images.githubusercontent.com/37080671/141524501-c4c27552-e818-4810-8dee-309b60d7a4d9.png)

