### PR TITLE
[bots] Replace obscure ternary operator with std::min

### DIFF
--- a/src/client/component/bots.cpp
+++ b/src/client/component/bots.cpp
@@ -122,7 +122,9 @@ namespace bots
 					num_bots = atoi(params.get(1));
 				}
 
-				for (auto i = 0; i < (num_bots > *game::mp::svs_numclients ? *game::mp::svs_numclients : num_bots); i++)
+				num_bots = std::min(num_bots, *game::mp::svs_numclients);
+
+				for (auto i = 0; i < num_bots; i++)
 				{
 					scheduler::once(add_bot, scheduler::pipeline::server, 100ms * i);
 				}


### PR DESCRIPTION
Should improve readability as the first time I read this code I was a bit confused.