### PR TITLE
[Utils] Further cleanup

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -346,8 +346,6 @@ links {"common"}
 
 resincludedirs {"$(ProjectDir)src"}
 
-links {"common"}
-
 dependencies.imports()
 
 group "Dependencies"

--- a/src/common/utils/info_string.cpp
+++ b/src/common/utils/info_string.cpp
@@ -36,7 +36,7 @@ namespace utils
 			buffer = buffer.substr(1);
 		}
 
-		auto key_values = string::split(buffer, '\\');
+		const auto key_values = string::split(buffer, '\\');
 		for (size_t i = 0; !key_values.empty() && i < (key_values.size() - 1); i += 2)
 		{
 			const auto& key = key_values[i];

--- a/src/common/utils/info_string.hpp
+++ b/src/common/utils/info_string.hpp
@@ -9,8 +9,8 @@ namespace utils
 	{
 	public:
 		info_string() = default;
-		info_string(const std::string& buffer);
-		info_string(const std::string_view& buffer);
+		explicit info_string(const std::string& buffer);
+		explicit info_string(const std::string_view& buffer);
 
 		void set(const std::string& key, const std::string& value);
 		std::string get(const std::string& key) const;

--- a/src/common/utils/io.cpp
+++ b/src/common/utils/io.cpp
@@ -64,7 +64,7 @@ namespace utils::io
 			if (size > -1)
 			{
 				data->resize(static_cast<uint32_t>(size));
-				stream.read(const_cast<char*>(data->data()), size);
+				stream.read(data->data(), size);
 				stream.close();
 				return true;
 			}

--- a/src/common/utils/memory.cpp
+++ b/src/common/utils/memory.cpp
@@ -14,7 +14,7 @@ namespace utils
 	{
 		std::lock_guard _(this->mutex_);
 
-		for (auto& data : this->pool_)
+		for (const auto& data : this->pool_)
 		{
 			memory::free(data);
 		}

--- a/src/common/utils/memory.hpp
+++ b/src/common/utils/memory.hpp
@@ -22,13 +22,13 @@ namespace utils
 			void* allocate(size_t length);
 
 			template <typename T>
-			inline T* allocate()
+			T* allocate()
 			{
 				return this->allocate_array<T>(1);
 			}
 
 			template <typename T>
-			inline T* allocate_array(const size_t count = 1)
+			T* allocate_array(const size_t count = 1)
 			{
 				return static_cast<T*>(this->allocate(count * sizeof(T)));
 			}
@@ -45,13 +45,13 @@ namespace utils
 		static void* allocate(size_t length);
 
 		template <typename T>
-		static inline T* allocate()
+		static T* allocate()
 		{
 			return allocate_array<T>(1);
 		}
 
 		template <typename T>
-		static inline T* allocate_array(const size_t count = 1)
+		static T* allocate_array(const size_t count = 1)
 		{
 			return static_cast<T*>(allocate(count * sizeof(T)));
 		}


### PR DESCRIPTION
Removes unnecessary const_casts.
Remove double `links` directive in the premake5 file.