### PR TITLE
Use ex from cppref for converting strings up/lower

### DIFF
--- a/src/common/utils/string.cpp
+++ b/src/common/utils/string.cpp
@@ -36,9 +36,9 @@ namespace utils::string
 
 	std::string to_lower(std::string text)
 	{
-		std::transform(text.begin(), text.end(), text.begin(), [](const char input)
+		std::transform(text.begin(), text.end(), text.begin(), [](const unsigned char input)
 		{
-			return static_cast<char>(tolower(input));
+			return static_cast<char>(std::tolower(input));
 		});
 
 		return text;
@@ -46,9 +46,9 @@ namespace utils::string
 
 	std::string to_upper(std::string text)
 	{
-		std::transform(text.begin(), text.end(), text.begin(), [](const char input)
+		std::transform(text.begin(), text.end(), text.begin(), [](const unsigned char input)
 		{
-			return static_cast<char>(toupper(input));
+			return static_cast<char>(std::toupper(input));
 		});
 
 		return text;


### PR DESCRIPTION
Their example:
https://en.cppreference.com/w/cpp/string/byte/toupper

We should use unsigned char instead of a signed char. This is of course to make the code more portable.

Notes: MSVC docs appear not to do this in their examples when using tolower/toupper indicating they may or may not handle this internally (converting char to int). The worst that can happen is that if you do not convert a char to an unsigned char 0xFF (-1) will be padded to 0xFFFFFFFF (because both function declaration is int tolower/toupper( int c ) ). If it's not defined by the implementation I don't know what would happen (undefined behaviour according to c++ standard). Credit to laupetin for this explanation I just sort of stumbled upon the cpppreference artclient and noticed this. Should be a nice addition :)