### PR TITLE
Fix cg fov check

### DIFF
--- a/src/client/component/patches.cpp
+++ b/src/client/component/patches.cpp
@@ -170,7 +170,7 @@ namespace patches
 
 		void set_client_dvar_from_server_stub(void* a1, void* a2, const char* dvar, const char* value)
 		{
-			if (dvar == "cg_fov"s)
+			if (utils::string::to_lower(dvar) == "cg_fov")
 			{
 				return;
 			}


### PR DESCRIPTION
I discovered if a server is modified to send a server command to change the fov that is like "Cg_FoV" this check is rendered useless.