### PR TITLE
LUI: Remove Access to IO functions

### DIFF
--- a/src/client/component/ui_scripting.cpp
+++ b/src/client/component/ui_scripting.cpp
@@ -138,17 +138,6 @@ namespace ui_scripting
 		{
 			const auto lua = get_globals();
 
-			lua["io"]["fileexists"] = utils::io::file_exists;
-			lua["io"]["writefile"] = utils::io::write_file;
-			lua["io"]["movefile"] = utils::io::move_file;
-			lua["io"]["filesize"] = utils::io::file_size;
-			lua["io"]["createdirectory"] = utils::io::create_directory;
-			lua["io"]["directoryexists"] = utils::io::directory_exists;
-			lua["io"]["directoryisempty"] = utils::io::directory_is_empty;
-			lua["io"]["listfiles"] = utils::io::list_files;
-			lua["io"]["removefile"] = utils::io::remove_file;
-			lua["io"]["readfile"] = static_cast<std::string(*)(const std::string&)>(utils::io::read_file);
-
 			using game = table;
 			auto game_type = game();
 			lua["game"] = game_type;


### PR DESCRIPTION
To allow what is know as an extremely vulnerable Havok VM to have unrestricted access to IO functions imposes such a great security risk it should be immediately removed.
There is no legitimate reason UI scripts need access to IO.
If we ever add mod downloading here, it would allow for so many things to go wrong...